### PR TITLE
(feat) Added support for AdminMode

### DIFF
--- a/bin/runner.go
+++ b/bin/runner.go
@@ -18,7 +18,7 @@ func main() {
 	}
 	// Fetching all the ENV's needed
 	utils.GetOsEnv(&engineDetails)
-	klog.V(0).Infoln("Experiments List: ", engineDetails.Experiments, " ", "Engine Name: ", engineDetails.Name, " ", "appLabels : ", engineDetails.AppLabel, " ", "appKind: ", engineDetails.AppKind, " ", "Service Account Name: ", engineDetails.SvcAccount)
+	klog.V(0).Infoln("Experiments List: ", engineDetails.Experiments, " ", "Engine Name: ", engineDetails.Name, " ", "appLabels : ", engineDetails.AppLabel, " ", "appKind: ", engineDetails.AppKind, " ", "Service Account Name: ", engineDetails.SvcAccount, "Engine Namespace: ", engineDetails.EngineNamespace)
 
 	recorder, err := utils.NewEventRecorder(clients, engineDetails)
 	if err != nil {

--- a/pkg/utils/experimentHelpers.go
+++ b/pkg/utils/experimentHelpers.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+	"os"
 )
 
 //SetValueFromChaosExperiment sets value in experimentDetails struct from chaosExperiment
@@ -33,7 +34,7 @@ func (expDetails *ExperimentDetails) SetENV(engineDetails EngineDetails, clients
 		return err
 	}
 	// Store ENV in a map
-	ENVList := map[string]string{"CHAOSENGINE": engineDetails.Name, "APP_LABEL": engineDetails.AppLabel, "ENGINE_NAMESPACE": engineDetails.EngineNamespace, "APP_NAMESPACE": expDetails.Namespace, "APP_KIND": engineDetails.AppKind, "AUXILIARY_APPINFO": engineDetails.AuxiliaryAppInfo, "CHAOS_UID": engineDetails.UID}
+	ENVList := map[string]string{"CHAOSENGINE": engineDetails.Name, "APP_LABEL": engineDetails.AppLabel, "ENGINE_NAMESPACE": engineDetails.EngineNamespace, "APP_NAMESPACE": os.Getenv("APP_NAMESPACE"), "APP_KIND": engineDetails.AppKind, "AUXILIARY_APPINFO": engineDetails.AuxiliaryAppInfo, "CHAOS_UID": engineDetails.UID}
 	// Adding some addition ENV's from spec.AppInfo of ChaosEngine
 	for key, value := range ENVList {
 		expDetails.Env[key] = value

--- a/pkg/utils/experimentHelpers.go
+++ b/pkg/utils/experimentHelpers.go
@@ -51,6 +51,7 @@ func NewExperimentDetails(engineDetails *EngineDetails, i int) *ExperimentDetail
 	// Initial set to values from EngineDetails Struct
 	experimentDetails.Name = engineDetails.Experiments[i]
 	experimentDetails.SvcAccount = engineDetails.SvcAccount
+	experimentDetails.Namespace = os.Getenv("CHAOS_NAMESPACE")
 
 	// Generation of Random String for appending it into Job Name
 	randomString := RandomString()
@@ -148,9 +149,7 @@ func (expDetails *ExperimentDetails) SetValueFromChaosResources(engineDetails *E
 
 	if err := engineDetails.SetValueFromChaosRunner(clients); err != nil {
 		return errors.Wrapf(err, "Unable to set value from Chaos Runner due to error: %v", err)
-
 	}
-	expDetails.SetNamespaceAccordingToAdminMode(engineDetails)
 	if err := expDetails.HandleChaosExperimentExistence(*engineDetails, clients); err != nil {
 		return errors.Wrapf(err, "Unable to get ChaosExperiment Name: %v, in namespace: %v, due to error: %v", expDetails.Name, expDetails.Namespace, err)
 	}
@@ -182,15 +181,6 @@ func (expDetails *ExperimentDetails) SetValueFromChaosEngine(engine *EngineDetai
 	if err != nil {
 		return errors.Wrapf(err, "Unable to get chaosEngine in namespace: %s", engine.EngineNamespace)
 	}
-	expDetails.Namespace = chaosEngine.Spec.Appinfo.Appns
+	expDetails.Namespace = chaosEngine.Namespace
 	return nil
-}
-
-func (expDetails *ExperimentDetails) SetNamespaceAccordingToAdminMode(engine *EngineDetails) {
-	klog.Infof("AdminMode set to: %v", engine.AdminMode)
-	if engine.AdminMode {
-		klog.Infof("AdminMode enabled, will change the experiment namespace to chaosEngine Namespace: %s", engine.EngineNamespace)
-		expDetails.Namespace = engine.EngineNamespace
-	}
-
 }

--- a/pkg/utils/getOSenv.go
+++ b/pkg/utils/getOSenv.go
@@ -10,7 +10,7 @@ func GetOsEnv(engineDetails *EngineDetails) {
 	experimentList := os.Getenv("EXPERIMENT_LIST")
 	engineDetails.Name = os.Getenv("CHAOSENGINE")
 	engineDetails.AppLabel = os.Getenv("APP_LABEL")
-	engineDetails.EngineNamespace = os.Getenv("ENGINE_NAMESPACE")
+	engineDetails.EngineNamespace = os.Getenv("CHAOS_NAMESPACE")
 	engineDetails.AppKind = os.Getenv("APP_KIND")
 	engineDetails.SvcAccount = os.Getenv("CHAOS_SVC_ACC")
 	engineDetails.ClientUUID = os.Getenv("CLIENT_UUID")

--- a/pkg/utils/getOSenv.go
+++ b/pkg/utils/getOSenv.go
@@ -10,7 +10,7 @@ func GetOsEnv(engineDetails *EngineDetails) {
 	experimentList := os.Getenv("EXPERIMENT_LIST")
 	engineDetails.Name = os.Getenv("CHAOSENGINE")
 	engineDetails.AppLabel = os.Getenv("APP_LABEL")
-	engineDetails.AppNamespace = os.Getenv("APP_NAMESPACE")
+	engineDetails.EngineNamespace = os.Getenv("ENGINE_NAMESPACE")
 	engineDetails.AppKind = os.Getenv("APP_KIND")
 	engineDetails.SvcAccount = os.Getenv("CHAOS_SVC_ACC")
 	engineDetails.ClientUUID = os.Getenv("CLIENT_UUID")

--- a/pkg/utils/getOSenv.go
+++ b/pkg/utils/getOSenv.go
@@ -16,4 +16,9 @@ func GetOsEnv(engineDetails *EngineDetails) {
 	engineDetails.ClientUUID = os.Getenv("CLIENT_UUID")
 	engineDetails.Experiments = strings.Split(experimentList, ",")
 	engineDetails.AuxiliaryAppInfo = os.Getenv("AUXILIARY_APPINFO")
+
+	engineDetails.AdminMode = false
+	if os.Getenv("ADMIN_MODE") == "true" {
+		engineDetails.AdminMode = true
+	}
 }

--- a/pkg/utils/getOSenv.go
+++ b/pkg/utils/getOSenv.go
@@ -17,8 +17,9 @@ func GetOsEnv(engineDetails *EngineDetails) {
 	engineDetails.Experiments = strings.Split(experimentList, ",")
 	engineDetails.AuxiliaryAppInfo = os.Getenv("AUXILIARY_APPINFO")
 
-	engineDetails.AdminMode = false
-	if os.Getenv("ADMIN_MODE") == "true" {
-		engineDetails.AdminMode = true
-	}
+	//TODO: Use engineDetails.AdminMode, to change behaviour of chaos-runner
+	// engineDetails.AdminMode = false
+	// if os.Getenv("ADMIN_MODE") == "true" {
+	// 	engineDetails.AdminMode = true
+	// }
 }

--- a/pkg/utils/initialPatchEngine.go
+++ b/pkg/utils/initialPatchEngine.go
@@ -18,9 +18,9 @@ func (expStatus *ExperimentStatus) InitialPatchEngine(engineDetails EngineDetail
 			return errors.Wrapf(err, "Unable to get ChaosEngine, due to error: %v", err)
 		}
 		expEngine.Status.Experiments = append(expEngine.Status.Experiments, v1alpha1.ExperimentStatuses(*expStatus))
-		_, updateErr := clients.LitmusClient.LitmuschaosV1alpha1().ChaosEngines(engineDetails.AppNamespace).Update(expEngine)
+		_, updateErr := clients.LitmusClient.LitmuschaosV1alpha1().ChaosEngines(engineDetails.EngineNamespace).Update(expEngine)
 		if updateErr != nil {
-			return errors.Wrapf(err, "Unable to update ChaosEngine in namespace: %v, due to error: %v", engineDetails.AppNamespace, err)
+			return errors.Wrapf(err, "Unable to update ChaosEngine in namespace: %v, due to error: %v", engineDetails.EngineNamespace, err)
 		}
 	}
 	return nil

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -27,7 +27,6 @@ type EngineDetails struct {
 	ClientUUID       string
 	AuxiliaryAppInfo string
 	UID              string
-	AdminMode        bool
 	EngineNamespace  string
 }
 

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -24,10 +24,11 @@ type EngineDetails struct {
 	AppLabel         string
 	SvcAccount       string
 	AppKind          string
-	AppNamespace     string
 	ClientUUID       string
 	AuxiliaryAppInfo string
 	UID              string
+	AdminMode        bool
+	EngineNamespace  string
 }
 
 // ExperimentDetails is for collecting all the experiment-related details


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

    - Replaced EngineDetails.AppNamespace to EngineDetails.EngineNamespace
    - Added logic to check for resources in chaosEngine namespace
    - Added OS ENV as CHAOS_NAMESPACE passed from operator, into engineDetails struct
    - EngineDetails.EngineNamespace will always keep experiment.Namespace in sync
    - All job related resources(job,configmaps,secrets etc) will be  in AppNamespace (experiment.Namespace)
    - All engine related resources will be in EngineNamespace(engineDetails.EngineNamespace)
    - Added OS ENV as CHAOS_NAMESPACE passed from operator, into engineDetails struct

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/litmuschaos/litmus/issues/1219
**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests