### PR TITLE
(feat) Added Event of ChaosEngine for Skipped Experiments

### DIFF
--- a/bin/runner.go
+++ b/bin/runner.go
@@ -41,6 +41,7 @@ func main() {
 
 		if err := experiment.SetENV(engineDetails, clients); err != nil {
 			klog.V(0).Infof("Unable to patch ENV due to error: %v", err)
+			recorder.ExperimentSkipped(engineDetails.Experiments[i])
 			break
 		}
 		experimentStatus := utils.ExperimentStatus{}
@@ -53,6 +54,7 @@ func main() {
 
 		if err := experiment.HandleChaosExperimentExistence(engineDetails, clients); err != nil {
 			klog.V(0).Infof("Unable to get ChaosExperiment Name: %v, in namespace: %v, due to error: %v", experiment.Name, experiment.Namespace, err)
+			recorder.ExperimentSkipped(engineDetails.Experiments[i])
 			break
 		}
 
@@ -65,6 +67,7 @@ func main() {
 		// Creation of PodTemplateSpec, and Final Job
 		if err := utils.BuildingAndLaunchJob(experiment, clients); err != nil {
 			klog.V(0).Infof("Unable to construct chaos experiment job due to: %v", err)
+			recorder.ExperimentSkipped(engineDetails.Experiments[i])
 			break
 		}
 		recorder.ExperimentJobCreate(engineDetails.Experiments[i], experiment.JobName)
@@ -74,6 +77,7 @@ func main() {
 		// Watching the Job till Completion
 		if err := engineDetails.WatchJobForCompletion(experiment, clients); err != nil {
 			klog.V(0).Infof("Unable to Watch the Job, error: %v", err)
+			recorder.ExperimentSkipped(engineDetails.Experiments[i])
 			break
 		}
 

--- a/bin/runner.go
+++ b/bin/runner.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"time"
-
 	"k8s.io/klog"
 
 	"github.com/litmuschaos/chaos-runner/pkg/utils"
@@ -41,7 +39,7 @@ func main() {
 
 		if err := experiment.SetENV(engineDetails, clients); err != nil {
 			klog.V(0).Infof("Unable to patch ENV due to error: %v", err)
-			recorder.ExperimentSkipped(engineDetails.Experiments[i])
+			recorder.ExperimentSkipped(engineDetails.Experiments[i], utils.ExperimentEnvParseErrorReason)
 			break
 		}
 		experimentStatus := utils.ExperimentStatus{}
@@ -54,7 +52,7 @@ func main() {
 
 		if err := experiment.HandleChaosExperimentExistence(engineDetails, clients); err != nil {
 			klog.V(0).Infof("Unable to get ChaosExperiment Name: %v, in namespace: %v, due to error: %v", experiment.Name, experiment.Namespace, err)
-			recorder.ExperimentSkipped(engineDetails.Experiments[i])
+			recorder.ExperimentSkipped(engineDetails.Experiments[i], utils.ExperimentNotFoundErrorReason)
 			break
 		}
 
@@ -67,17 +65,16 @@ func main() {
 		// Creation of PodTemplateSpec, and Final Job
 		if err := utils.BuildingAndLaunchJob(experiment, clients); err != nil {
 			klog.V(0).Infof("Unable to construct chaos experiment job due to: %v", err)
-			recorder.ExperimentSkipped(engineDetails.Experiments[i])
+			recorder.ExperimentSkipped(engineDetails.Experiments[i], utils.ExperimentJobCreationErrorReason)
 			break
 		}
 		recorder.ExperimentJobCreate(engineDetails.Experiments[i], experiment.JobName)
-		time.Sleep(5 * time.Second)
 
 		klog.V(0).Infof("Started Chaos Experiment Name: %v, with Job Name: %v", experiment.Name, experiment.JobName)
 		// Watching the Job till Completion
 		if err := engineDetails.WatchJobForCompletion(experiment, clients); err != nil {
 			klog.V(0).Infof("Unable to Watch the Job, error: %v", err)
-			recorder.ExperimentSkipped(engineDetails.Experiments[i])
+			recorder.ExperimentSkipped(engineDetails.Experiments[i], utils.ExperimentJobWatchErrorReason)
 			break
 		}
 
@@ -92,6 +89,5 @@ func main() {
 			klog.V(0).Infof("Unable to Delete ChaosExperiment Job due to: %v", err)
 		}
 		recorder.ExperimentJobCleanUp(experiment, jobCleanUpPolicy)
-		time.Sleep(5 * time.Second)
 	}
 }

--- a/pkg/utils/recorder.go
+++ b/pkg/utils/recorder.go
@@ -69,5 +69,5 @@ func (r Recorder) ExperimentJobCleanUp(experiment *ExperimentDetails, jobCleanUp
 // ExperimentSkipped is an standard event spawned just after
 // an experiment is skipped
 func (r Recorder) ExperimentSkipped(experimentName string) {
-	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, experimentSkipped, "Experiment Job creation failed, skipping Chaos Experiment: '%s'", experimentName)
+	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeWarning, experimentSkipped, "Experiment Job creation failed, skipping Chaos Experiment: '%s'", experimentName)
 }

--- a/pkg/utils/recorder.go
+++ b/pkg/utils/recorder.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"time"
 
 	litmuschaosScheme "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/scheme"
 )
@@ -37,37 +38,35 @@ func NewEventRecorder(clients ClientSets, engineDetails EngineDetails) (*Recorde
 	}, nil
 }
 
-const (
-	experimentDependencyCheck string = "ExperimentDependencyCheck"
-	experimentJobCreate       string = "ExperimentJobCreate"
-	experimentJobCleanUp      string = "ExperimentJobCleanUp"
-	experimentSkipped         string = "ExperimentSkipped"
-)
-
 // ExperimentDepedencyCheck is an standard event spawned just after validating
 // experiment dependent resources such as ChaosExperiment, ConfigMaps and Secrets.
 func (r Recorder) ExperimentDepedencyCheck(experimentName string) {
-	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, experimentDependencyCheck, "Experiment resources validated for Chaos Experiment: '%s'", experimentName)
+	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, ExperimentDependencyCheckReason, "Experiment resources validated for Chaos Experiment: '%s'", experimentName)
+	time.Sleep(5 * time.Second)
 }
 
 // ExperimentJobCreate is an standard event spawned just after
 // starting chaosExperiment Job
 func (r Recorder) ExperimentJobCreate(experimentName string, jobName string) {
-	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, experimentJobCreate, "Experiment Job '%s' created for Chaos Experiment '%s'", jobName, experimentName)
+	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, ExperimentJobCreateReason, "Experiment Job '%s' created for Chaos Experiment '%s'", jobName, experimentName)
+	time.Sleep(5 * time.Second)
 }
 
 // ExperimentJobCleanUp is an standard event spawned just after
 // starting ChaosExperiment Job
 func (r Recorder) ExperimentJobCleanUp(experiment *ExperimentDetails, jobCleanUpPolicy string) {
 	if jobCleanUpPolicy == "delete" {
-		r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, experimentJobCleanUp, "Experiment Job '%s' is deleted", experiment.JobName)
+		r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, ExperimentJobCleanUpReason, "Experiment Job '%s' is deleted", experiment.JobName)
+		time.Sleep(5 * time.Second)
 	} else {
-		r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, experimentJobCleanUp, "Experiment Job '%s' will be retained", experiment.JobName)
+		r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeNormal, ExperimentJobCleanUpReason, "Experiment Job '%s' will be retained", experiment.JobName)
+		time.Sleep(5 * time.Second)
 	}
 }
 
 // ExperimentSkipped is an standard event spawned just after
 // an experiment is skipped
-func (r Recorder) ExperimentSkipped(experimentName string) {
-	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeWarning, experimentSkipped, "Experiment Job creation failed, skipping Chaos Experiment: '%s'", experimentName)
+func (r Recorder) ExperimentSkipped(experimentName string, reason string) {
+	r.EventRecorder.Eventf(r.EventResource, corev1.EventTypeWarning, reason, "Experiment Job creation failed, skipping Chaos Experiment: '%s'", experimentName)
+	time.Sleep(5 * time.Second)
 }

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -63,6 +63,17 @@ type Recorder struct {
 	EventResource runtime.Object
 }
 
+const (
+	ExperimentDependencyCheckReason  string = "ExperimentDependencyCheck"
+	ExperimentJobCreateReason        string = "ExperimentJobCreate"
+	ExperimentJobCleanUpReason       string = "ExperimentJobCleanUp"
+	ExperimentSkippedReason          string = "ExperimentSkipped"
+	ExperimentEnvParseErrorReason    string = "EnvParseError"
+	ExperimentNotFoundErrorReason    string = "ExperimentNotFound"
+	ExperimentJobCreationErrorReason string = "JobCreationError"
+	ExperimentJobWatchErrorReason    string = "JobWatchNotPermitted"
+)
+
 // GenerateClientSetFromKubeConfig will generation both ClientSets (k8s, and Litmus)
 func (clientSets *ClientSets) GenerateClientSetFromKubeConfig() error {
 	config, err := getKubeConfig()


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Adds a blanket event signifying runners failure to create the experiment job. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

    - https://github.com/litmuschaos/chaos-runner/issues/54
**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests