### PR TITLE
(fix) Added name of the runner Pod in ChaosEngine Events

### DIFF
--- a/pkg/utils/recorder.go
+++ b/pkg/utils/recorder.go
@@ -11,14 +11,14 @@ import (
 	litmuschaosScheme "github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/scheme"
 )
 
-func generateEventRecorder(kubeClient *kubernetes.Clientset) (record.EventRecorder, error) {
+func generateEventRecorder(kubeClient *kubernetes.Clientset, componentName string) (record.EventRecorder, error) {
 	err := litmuschaosScheme.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return nil, err
 	}
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "chaos-runner"})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: componentName})
 	return recorder, nil
 }
 
@@ -28,7 +28,7 @@ func NewEventRecorder(clients ClientSets, engineDetails EngineDetails) (*Recorde
 	if err != nil {
 		return &Recorder{}, err
 	}
-	eventBroadCaster, err := generateEventRecorder(clients.KubeClient)
+	eventBroadCaster, err := generateEventRecorder(clients.KubeClient, engineDetails.Name+"-runner")
 	if err != nil {
 		return &Recorder{}, err
 	}


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
    - In this PR, fixed the name of the components shown in chaosengine events.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/litmuschaos/litmus/issues/1326
**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests