### PR TITLE
chore(Dockerfile): Add user_id in the Dockerfile of chaos-runner

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,8 +2,12 @@ FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
 
 LABEL maintainer="LitmusChaos"
 
-ENV RUNNER=/usr/local/bin/chaos-runner
+ENV RUNNER=/usr/local/bin/chaos-runner \
+    USER_UID=1001 \
+    USER_NAME=chaos-runner
 
 COPY build/_output/bin/chaos-runner ${RUNNER}
 
 ENTRYPOINT ["/usr/local/bin/chaos-runner"]
+
+USER ${USER_UID}


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR is for addition of user_id in the Dockerfile of chaos-runner to run it as non root user.
A GitLab run with the given changes in the image: https://gitlab.mayadata.io/litmuschaos/litmus-e2e/pipelines/12501

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests