### PR TITLE
chore(continuous-probe): Adding the continuous probes in go experiments

### DIFF
--- a/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -253,6 +253,9 @@ type RunProperty struct {
 	Interval int `json:"interval,omitempty"`
 	// Retry contains the retry count for the probe
 	Retry int `json:"retry,omitempty"`
+	//ProbePollingInterval contains time interval, for which continuous probe should be sleep
+	// after each iteration
+	ProbePollingInterval int `json:"probePollingInterval,omitempty"`
 }
 
 // ExperimentComponents contains ENV, Configmaps and Secrets
@@ -281,7 +284,7 @@ type ExperimentENV struct {
 // ExperimentStatuses defines information about status of individual experiments
 // These fields are immutable, and are derived by kubernetes(operator)
 type ExperimentStatuses struct {
-	//Name of the chaos experiment 
+	//Name of the chaos experiment
 	Name string `json:"name"`
 	//Name of chaos-runner pod managing this experiment
 	Runner string `json:"runner"`


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- For the continuous probe an extra variable is required in run properties. It contains the time interval for which we have to wait after each iteration of the continuous probe.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests