### PR TITLE
Move ENVs to corev1.EnvVar instead of custom struct

### DIFF
--- a/pkg/utils/environment.go
+++ b/pkg/utils/environment.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/litmuschaos/chaos-runner/pkg/log"
 )
 
@@ -60,7 +62,10 @@ func (expDetails *ExperimentDetails) SetENV(engineDetails EngineDetails, clients
 	}
 	// Adding some additional ENV's from spec.AppInfo of ChaosEngine// Adding some additional ENV's from spec.AppInfo of ChaosEngine
 	for key, value := range ENVList {
-		expDetails.Env[key] = value
+		expDetails.envMap[key] = v1.EnvVar{
+			Name:  key,
+			Value: value,
+		}
 	}
 	return nil
 }

--- a/pkg/utils/experimentHelper.go
+++ b/pkg/utils/experimentHelper.go
@@ -3,6 +3,7 @@ package utils
 import (
 	litmuschaosv1alpha1 "github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -18,7 +19,7 @@ func (engineDetails *EngineDetails) CreateExperimentList() []ExperimentDetails {
 // NewExperimentDetails create and initialize the experimentDetails
 func (engineDetails *EngineDetails) NewExperimentDetails(i int) ExperimentDetails {
 	var experimentDetails ExperimentDetails
-	experimentDetails.Env = make(map[string]string)
+	experimentDetails.envMap = make(map[string]v1.EnvVar)
 	experimentDetails.ExpLabels = make(map[string]string)
 
 	// set the initial values from the EngineDetails struct
@@ -37,13 +38,11 @@ func (expDetails *ExperimentDetails) SetDefaultEnvFromChaosExperiment(clients Cl
 		return errors.Errorf("Unable to get the %v ChaosExperiment in %v namespace, error: %v", expDetails.Name, expDetails.Namespace, err)
 	}
 
-	expDetails.Env = make(map[string]string)
 	envList := experimentEnv.Spec.Definition.ENVList
-	for i := range envList {
-		key := envList[i].Name
-		value := envList[i].Value
-		expDetails.Env[key] = value
+	for _, env := range envList {
+		expDetails.envMap[env.Name] = env
 	}
+
 	return nil
 }
 

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -35,7 +35,7 @@ type EngineDetails struct {
 // ExperimentDetails is for collecting all the experiment-related details
 type ExperimentDetails struct {
 	Name               string
-	Env                map[string]string
+	envMap             map[string]corev1.EnvVar
 	ExpLabels          map[string]string
 	ExpImage           string
 	ExpImagePullPolicy corev1.PullPolicy

--- a/pkg/utils/watchJob.go
+++ b/pkg/utils/watchJob.go
@@ -59,9 +59,9 @@ func GetResultName(engineName, experimentName, instanceID string) string {
 }
 
 // GetChaosResult returns ChaosResult object.
-func (experimentDetails *ExperimentDetails) GetChaosResult(engineDetails EngineDetails, clients ClientSets) (*v1alpha1.ChaosResult, error) {
+func (expDetails *ExperimentDetails) GetChaosResult(engineDetails EngineDetails, clients ClientSets) (*v1alpha1.ChaosResult, error) {
 
-	resultName := GetResultName(engineDetails.Name, experimentDetails.Name, experimentDetails.InstanceID)
+	resultName := GetResultName(engineDetails.Name, expDetails.Name, expDetails.InstanceID)
 	expResult, err := clients.LitmusClient.LitmuschaosV1alpha1().ChaosResults(engineDetails.EngineNamespace).Get(resultName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Errorf("Unable to get ChaosResult Name: %v in namespace: %v, error: %v", resultName, engineDetails.EngineNamespace, err)

--- a/tests/runner_test.go
+++ b/tests/runner_test.go
@@ -233,16 +233,21 @@ var _ = Describe("BDD on chaos-runner", func() {
 			Expect(string(runner.Status.Phase)).To(Or(Equal("Running"), Equal("Succeeded")))
 		})
 	})
-	var jobName string
+
 	When("Check if the Job is spawned by chaos-runner", func() {
 		It("Should create a Pod delete Job", func() {
+
+			var jobName string
 			jobs, _ := k8sClientSet.BatchV1().Jobs("litmus").List(metav1.ListOptions{})
-			for i := range jobs.Items {
-				matched, _ := regexp.MatchString("pod-delete-.*", jobs.Items[i].Name)
-				if matched == true {
-					jobName = jobs.Items[i].Name
+
+			for _, job := range jobs.Items {
+				matched, _ := regexp.MatchString("pod-delete-.*", job.Name)
+				if matched {
+					jobName = job.Name
+					break
 				}
 			}
+
 			Expect(jobName).To(
 				Not(BeEmpty()),
 				"Unable to get the job, might be something wrong with chaos-runner",


### PR DESCRIPTION
Fixes litmuschaos/litmus#2368

Previously, ENVs can only use plain text.
This patch allows to use corev1.EnvVar at CR schema so that it can get value from secret/configmap/downwardAPI.

- Refactored some receiver/variable names to be consistent
- Used for-range values instead of using indices

Signed-off-by: kazukousen <mmchari.0228@gmail.com>
