### PR TITLE
chore(volumes): fix the volume builder operations

### DIFF
--- a/pkg/utils/volumeUtils.go
+++ b/pkg/utils/volumeUtils.go
@@ -41,6 +41,9 @@ func (volumeOpts *VolumeOpts) NewVolumeBuilder() *VolumeOpts {
 // BuildVolumeMountsForConfigMaps builds VolumeMounts for ConfigMaps
 func (volumeOpts *VolumeOpts) BuildVolumeMountsForConfigMaps(configMaps []v1alpha1.ConfigMap) *VolumeOpts {
 	var volumeMountsList []corev1.VolumeMount
+	if configMaps == nil {
+		return volumeOpts
+	}
 	for _, v := range configMaps {
 		var volumeMount corev1.VolumeMount
 		volumeMount.Name = v.Name
@@ -55,6 +58,9 @@ func (volumeOpts *VolumeOpts) BuildVolumeMountsForConfigMaps(configMaps []v1alph
 // BuildVolumeMountsForSecrets builds VolumeMounts for Secrets
 func (volumeOpts *VolumeOpts) BuildVolumeMountsForSecrets(secrets []v1alpha1.Secret) *VolumeOpts {
 	var volumeMountsList []corev1.VolumeMount
+	if secrets == nil {
+		return volumeOpts
+	}
 	for _, v := range secrets {
 		var volumeMount corev1.VolumeMount
 		volumeMount.Name = v.Name
@@ -68,7 +74,9 @@ func (volumeOpts *VolumeOpts) BuildVolumeMountsForSecrets(secrets []v1alpha1.Sec
 // BuildVolumeMountsForHostFileVolumes  builds VolumeMounts for HostFileVolume
 func (volumeOpts *VolumeOpts) BuildVolumeMountsForHostFileVolumes(hostFileVolumes []v1alpha1.HostFile) *VolumeOpts {
 	var volumeMountsList []corev1.VolumeMount
-
+	if hostFileVolumes == nil {
+		return volumeOpts
+	}
 	for _, v := range hostFileVolumes {
 		var volumeMount corev1.VolumeMount
 		volumeMount.Name = v.Name
@@ -83,7 +91,7 @@ func (volumeOpts *VolumeOpts) BuildVolumeMountsForHostFileVolumes(hostFileVolume
 func (volumeOpts *VolumeOpts) BuildVolumeBuilderForConfigMaps(configMaps []v1alpha1.ConfigMap) *VolumeOpts {
 	volumeBuilderList := []*volume.Builder{}
 	if configMaps == nil {
-		return nil
+		return volumeOpts
 	}
 	for _, v := range configMaps {
 		volumeBuilder := volume.NewBuilder().
@@ -98,7 +106,7 @@ func (volumeOpts *VolumeOpts) BuildVolumeBuilderForConfigMaps(configMaps []v1alp
 func (volumeOpts *VolumeOpts) BuildVolumeBuilderForSecrets(secrets []v1alpha1.Secret) *VolumeOpts {
 	volumeBuilderList := []*volume.Builder{}
 	if secrets == nil {
-		return nil
+		return volumeOpts
 	}
 	for _, v := range secrets {
 		volumeBuilder := volume.NewBuilder().
@@ -113,7 +121,7 @@ func (volumeOpts *VolumeOpts) BuildVolumeBuilderForSecrets(secrets []v1alpha1.Se
 func (volumeOpts *VolumeOpts) BuildVolumeBuilderForHostFileVolumes(hostFileVolumes []v1alpha1.HostFile) *VolumeOpts {
 	volumeBuilderList := []*volume.Builder{}
 	if hostFileVolumes == nil {
-		return nil
+		return volumeOpts
 	}
 
 	for _, v := range hostFileVolumes {


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- If configmaps was not defined, it was returning nil volumeopts instance, which was creating a problem if configmap is not defined but secrets is defined as builder received a nil instance for the secrets and it's tried to access `volumeopts.VolumeBuilders` which was causing an issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests