### PR TITLE
chore(terminationGracePeriodSeconds): Add support for termination grace period seconds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/jpillora/go-ogle-analytics v0.0.0-20161213085824-14b04e0594ef
-	github.com/litmuschaos/chaos-operator v0.0.0-20210312154932-c2d4b2ff7b19
-	github.com/litmuschaos/elves v0.0.0-20201107015738-552d74669e3c
+	github.com/litmuschaos/chaos-operator v0.0.0-20210325093226-50a357ad2256
+	github.com/litmuschaos/elves v0.0.0-20210325101625-5620f93aed51
 	github.com/litmuschaos/litmus-go v0.0.0-20201015093552-b88e93ffc452
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -452,12 +452,14 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/litmuschaos/chaos-operator v0.0.0-20201005102541-be0f9bb115ce h1:pB9ba9swCB3tUYngzP3RMlLPuEAGYxmfTL/G0e3zs04=
 github.com/litmuschaos/chaos-operator v0.0.0-20201005102541-be0f9bb115ce/go.mod h1:J4NuADZBn6nUkhKNux3p3ghSUfxoB+itsO+rD8tOCNk=
-github.com/litmuschaos/chaos-operator v0.0.0-20210312154932-c2d4b2ff7b19 h1:k3qTu0NiBd5PMwA9O0EZ6J0vZjeFS6UqP4IZ1ISd0vQ=
-github.com/litmuschaos/chaos-operator v0.0.0-20210312154932-c2d4b2ff7b19/go.mod h1:Z2GpYjqXwFd8bx+kv58YEQFxynx1v9PMGCGTQFRVnFQ=
+github.com/litmuschaos/chaos-operator v0.0.0-20210325093226-50a357ad2256 h1:Za6YLg56j3QRNTv7gtReZxGN7Vp09zCbZttOL2DY4Ik=
+github.com/litmuschaos/chaos-operator v0.0.0-20210325093226-50a357ad2256/go.mod h1:Z2GpYjqXwFd8bx+kv58YEQFxynx1v9PMGCGTQFRVnFQ=
 github.com/litmuschaos/elves v0.0.0-20200930100735-5efe29d0ad5b h1:eYT2CfSf7FZu01DAgxgjrlSc7dX5IlwPRqD44RH47Kk=
 github.com/litmuschaos/elves v0.0.0-20200930100735-5efe29d0ad5b/go.mod h1:DsbHGNUq/78NZozWVVI9Q6eBei4I+JjlkkD5aibJ3MQ=
 github.com/litmuschaos/elves v0.0.0-20201107015738-552d74669e3c h1:+hlppERdpCxMRW0QC+ckbz/mS6wH+fNVMlDMFGClk7U=
 github.com/litmuschaos/elves v0.0.0-20201107015738-552d74669e3c/go.mod h1:DsbHGNUq/78NZozWVVI9Q6eBei4I+JjlkkD5aibJ3MQ=
+github.com/litmuschaos/elves v0.0.0-20210325101625-5620f93aed51 h1:6CpcGjZsVHMRSB/Z8z9+ectmb1KuQUiy+244jISNhBA=
+github.com/litmuschaos/elves v0.0.0-20210325101625-5620f93aed51/go.mod h1:DsbHGNUq/78NZozWVVI9Q6eBei4I+JjlkkD5aibJ3MQ=
 github.com/litmuschaos/litmus-go v0.0.0-20201015093552-b88e93ffc452 h1:ZC/dhFHbzpibZAxLT9Pp2IPcAnEusIN6W6IMepkT9ck=
 github.com/litmuschaos/litmus-go v0.0.0-20201015093552-b88e93ffc452/go.mod h1:vS08ynv8o7+AjLwP6vhUjgcB5JM0zVq2AFWWW8P6q48=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=

--- a/pkg/utils/builders.go
+++ b/pkg/utils/builders.go
@@ -131,6 +131,10 @@ func buildPodTemplateSpec(experiment *ExperimentDetails, containerForPod *contai
 		WithAnnotations(experiment.Annotations).
 		WithContainerBuildersNew(containerForPod)
 
+	if experiment.TerminationGracePeriodSeconds != 0 {
+		podtemplate.WithTerminationGracePeriodSeconds(experiment.TerminationGracePeriodSeconds)
+	}
+
 	if !reflect.DeepEqual(experiment.SecurityContext.PodSecurityContext, corev1.PodSecurityContext{}) {
 
 		podtemplate.WithSecurityContext(experiment.SecurityContext.PodSecurityContext)

--- a/pkg/utils/engineHelper.go
+++ b/pkg/utils/engineHelper.go
@@ -23,7 +23,8 @@ func (expDetails *ExperimentDetails) SetInstanceAttributeValuesFromChaosEngine(e
 		SetResourceRequirementsFromEngine(chaosEngine).
 		SetImagePullSecretsFromEngine(chaosEngine).
 		SetTolerationsFromEngine(chaosEngine).
-		SetExpImageFromEngine(chaosEngine)
+		SetExpImageFromEngine(chaosEngine).
+		SetTerminationGracePeriodSecondsFromEngine(chaosEngine)
 
 	return nil
 }
@@ -85,6 +86,12 @@ func (expDetails *ExperimentDetails) SetExpNodeSelectorFromEngine(engine *litmus
 			expDetails.NodeSelector = expRefList[i].Spec.Components.NodeSelector
 		}
 	}
+	return expDetails
+}
+
+// SetTerminationGracePeriodSecondsFromEngine set the terminationGracePeriodSeconds for experiment pod provided in the chaosEngine
+func (expDetails *ExperimentDetails) SetTerminationGracePeriodSecondsFromEngine(engine *litmuschaosv1alpha1.ChaosEngine) *ExperimentDetails {
+	expDetails.TerminationGracePeriodSeconds = engine.Spec.TerminationGracePeriodSeconds
 	return expDetails
 }
 

--- a/pkg/utils/environment.go
+++ b/pkg/utils/environment.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -49,17 +50,18 @@ func (expDetails *ExperimentDetails) SetENV(engineDetails EngineDetails, clients
 	}
 	// Store ENV in a map
 	ENVList := map[string]string{
-		"CHAOSENGINE":           engineDetails.Name,
-		"APP_LABEL":             engineDetails.AppLabel,
-		"CHAOS_NAMESPACE":       engineDetails.EngineNamespace,
-		"APP_NAMESPACE":         engineDetails.AppNs,
-		"APP_KIND":              engineDetails.AppKind,
-		"AUXILIARY_APPINFO":     engineDetails.AuxiliaryAppInfo,
-		"CHAOS_UID":             engineDetails.UID,
-		"EXPERIMENT_NAME":       expDetails.Name,
-		"ANNOTATION_KEY":        engineDetails.AnnotationKey,
-		"ANNOTATION_CHECK":      engineDetails.AnnotationCheck,
-		"LIB_IMAGE_PULL_POLICY": string(expDetails.ExpImagePullPolicy),
+		"CHAOSENGINE":                      engineDetails.Name,
+		"APP_LABEL":                        engineDetails.AppLabel,
+		"CHAOS_NAMESPACE":                  engineDetails.EngineNamespace,
+		"APP_NAMESPACE":                    engineDetails.AppNs,
+		"APP_KIND":                         engineDetails.AppKind,
+		"AUXILIARY_APPINFO":                engineDetails.AuxiliaryAppInfo,
+		"CHAOS_UID":                        engineDetails.UID,
+		"EXPERIMENT_NAME":                  expDetails.Name,
+		"ANNOTATION_KEY":                   engineDetails.AnnotationKey,
+		"ANNOTATION_CHECK":                 engineDetails.AnnotationCheck,
+		"LIB_IMAGE_PULL_POLICY":            string(expDetails.ExpImagePullPolicy),
+		"TERMINATION_GRACE_PERIOD_SECONDS": strconv.Itoa(int(expDetails.TerminationGracePeriodSeconds)),
 	}
 	// Adding some additional ENV's from spec.AppInfo of ChaosEngine// Adding some additional ENV's from spec.AppInfo of ChaosEngine
 	for key, value := range ENVList {

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -54,10 +54,11 @@ type ExperimentDetails struct {
 	HostPID            bool
 	// InstanceID is passed as env inside chaosengine
 	// It is separately specified here because this attribute is common for all experiment.
-	InstanceID           string
-	ResourceRequirements v1.ResourceRequirements
-	ImagePullSecrets     []corev1.LocalObjectReference
-	StatusCheckTimeout   int
+	InstanceID                    string
+	ResourceRequirements          v1.ResourceRequirements
+	ImagePullSecrets              []corev1.LocalObjectReference
+	StatusCheckTimeout            int
+	TerminationGracePeriodSeconds int64
 }
 
 //VolumeOpts is a strcuture for all volume related operations

--- a/tests/runner_test.go
+++ b/tests/runner_test.go
@@ -206,7 +206,6 @@ var _ = Describe("BDD on chaos-runner", func() {
 							Type:  "go",
 						},
 					},
-					Monitoring: true,
 					Experiments: []v1alpha1.ExperimentList{
 						{
 							Name: "pod-delete",

--- a/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
+++ b/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosengine_types.go
@@ -36,14 +36,14 @@ type ChaosEngineSpec struct {
 	Components ComponentParams `json:"components"`
 	//Consists of experiments executed by the engine
 	Experiments []ExperimentList `json:"experiments"`
-	//Monitor Enable Status
-	Monitoring bool `json:"monitoring,omitempty"`
 	//JobCleanUpPolicy decides to retain or delete the jobs
 	JobCleanUpPolicy CleanUpPolicy `json:"jobCleanUpPolicy,omitempty"`
 	//AuxiliaryAppInfo contains details of dependent applications (infra chaos)
 	AuxiliaryAppInfo string `json:"auxiliaryAppInfo,omitempty"`
 	//EngineStatus is a requirement for validation
 	EngineState EngineState `json:"engineState"`
+	// TerminationGracePeriodSeconds contains terminationGracePeriod for the chaos resources
+	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds,omitempty"`
 }
 
 // EngineState provides interface for all supported strings in spec.EngineState
@@ -140,7 +140,7 @@ type RunnerInfo struct {
 	//ImagePullSecrets for runner pod
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// Runner Annotations that needs to be provided in the pod for pod that is getting created
-	RunnerAnnotation map[string]string `json:"runnerannotation,omitempty"`
+	RunnerAnnotation map[string]string `json:"runnerAnnotations,omitempty"`
 	// NodeSelector for runner pod
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// ConfigMaps for runner pod
@@ -315,7 +315,7 @@ type ExperimentComponents struct {
 	ENV                        []corev1.EnvVar               `json:"env,omitempty"`
 	ConfigMaps                 []ConfigMap                   `json:"configMaps,omitempty"`
 	Secrets                    []Secret                      `json:"secrets,omitempty"`
-	ExperimentAnnotations      map[string]string             `json:"experimentannotation,omitempty"`
+	ExperimentAnnotations      map[string]string             `json:"experimentAnnotations,omitempty"`
 	ExperimentImage            string                        `json:"experimentImage,omitempty"`
 	ExperimentImagePullSecrets []corev1.LocalObjectReference `json:"experimentImagePullSecrets,omitempty"`
 	NodeSelector               map[string]string             `json:"nodeSelector,omitempty"`

--- a/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
+++ b/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosexperiment_types.go
@@ -54,9 +54,9 @@ type Secret struct {
 
 // HostFile is an simpler implementation of corev1.HostPath, needed for experiments
 type HostFile struct {
-	Name      string `json:"name"`
-	MountPath string `json:"mountPath"`
-	NodePath  string `json:"nodePath"`
+	Name      string              `json:"name"`
+	MountPath string              `json:"mountPath"`
+	NodePath  string              `json:"nodePath"`
 	Type      corev1.HostPathType `json:"type,omitempty"`
 }
 
@@ -80,13 +80,13 @@ type ExperimentDef struct {
 	// Defines arguments to runner's entrypoint command
 	Args []string `json:"args"`
 	// ConfigMaps contains a list of ConfigMaps
-	ConfigMaps []ConfigMap `json:"configmaps,omitempty"`
+	ConfigMaps []ConfigMap `json:"configMaps,omitempty"`
 	// Secrets contains a list of Secrets
 	Secrets []Secret `json:"secrets,omitempty"`
 	// HostFileVolume defines the host directory/file to be mounted
 	HostFileVolumes []HostFile `json:"hostFileVolumes,omitempty"`
 	// Annotations that needs to be provided in the pod for pod that is getting created
-	ExperimentAnnotations map[string]string `json:"experimentannotations,omitempty"`
+	ExperimentAnnotations map[string]string `json:"experimentAnnotations,omitempty"`
 	// SecurityContext holds security configuration that will be applied to a container
 	SecurityContext SecurityContext `json:"securityContext,omitempty"`
 	// HostPID is need to be provided in the chaospod

--- a/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosresult_types.go
+++ b/vendor/github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1/chaosresult_types.go
@@ -41,7 +41,7 @@ type ChaosResultStatus struct {
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
 	// ExperimentStatus contains the status,verdict of the experiment
-	ExperimentStatus TestStatus `json:"experimentstatus"`
+	ExperimentStatus TestStatus `json:"experimentStatus"`
 	// ProbeStatus contains the status of the probe
 	ProbeStatus []ProbeStatus `json:"probeStatus,omitempty"`
 	// History contains cumulative values of verdicts

--- a/vendor/github.com/litmuschaos/elves/kubernetes/podtemplatespec/podtemplatespec.go
+++ b/vendor/github.com/litmuschaos/elves/kubernetes/podtemplatespec/podtemplatespec.go
@@ -100,7 +100,6 @@ func (b *Builder) WithAnnotationsNew(annotations map[string]string) *Builder {
 	return b
 }
 
-
 // WithNodeSelector merges the nodeselectors if present
 // with the provided arguments
 func (b *Builder) WithNodeSelector(nodeselectors map[string]string) *Builder {
@@ -435,16 +434,23 @@ func (b *Builder) WithHostPID(hostPID bool) *Builder {
 
 // WithImagePullSecrets sets the image pull secret for the container
 func (b *Builder) WithImagePullSecrets(secrets []corev1.LocalObjectReference) *Builder {
-    if len(secrets) == 0 {
-        b.errs = append(
-            b.errs,
-            errors.New(
-                "failed to build container object: missing imagepullsecrets",
-            ),
-        )
-        return b
-    }
+	if len(secrets) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build container object: missing imagepullsecrets",
+			),
+		)
+		return b
+	}
 
-    b.podtemplatespec.Object.Spec.ImagePullSecrets = secrets
-    return b
+	b.podtemplatespec.Object.Spec.ImagePullSecrets = secrets
+	return b
+}
+
+// WithTerminationGracePeriodSeconds sets the termination grace period seconds to pod
+func (b *Builder) WithTerminationGracePeriodSeconds(gracePeriod int64) *Builder {
+
+	b.podtemplatespec.Object.Spec.TerminationGracePeriodSeconds = &gracePeriod
+	return b
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,14 +48,14 @@ github.com/jpillora/go-ogle-analytics
 github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/litmuschaos/chaos-operator v0.0.0-20210312154932-c2d4b2ff7b19
+# github.com/litmuschaos/chaos-operator v0.0.0-20210325093226-50a357ad2256
 github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1
 github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned
 github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/fake
 github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/scheme
 github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1
 github.com/litmuschaos/chaos-operator/pkg/client/clientset/versioned/typed/litmuschaos/v1alpha1/fake
-# github.com/litmuschaos/elves v0.0.0-20201107015738-552d74669e3c
+# github.com/litmuschaos/elves v0.0.0-20210325101625-5620f93aed51
 github.com/litmuschaos/elves/kubernetes/container
 github.com/litmuschaos/elves/kubernetes/job
 github.com/litmuschaos/elves/kubernetes/jobspec


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Adding support for the termination grace period seconds of the experiment & helper pod. Which can be provided at `.spec.experiments[*].spec.components.terminationGracePeriodSeconds` path inside chaosengine.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests