### PR TITLE
(chore)ci: upper higher run time for bdd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,10 @@ jobs:
       - run: make build
       - run: |
           docker buildx build --file build/Dockerfile --platform linux/arm64,linux/amd64 --tag ${REPONAME}/${IMGNAME}:${IMGTAG} .    
-      - run: make test
+      - run: 
+          command: make test
+          no_output_timeout: 20m
+        
 
   trivy-check:
     machine: true

--- a/tests/runner_test.go
+++ b/tests/runner_test.go
@@ -263,6 +263,11 @@ var _ = Describe("BDD on chaos-runner", func() {
 
 })
 
+
+// This is a workaround to prevent a condition where operator expects presence of chaosresult to update target revert status
+// Also, this minikube is a transient cluster brought up in the pipeline VM, so we cna skip the cleanup
+/*
+
 //Deleting all unused resources
 var _ = AfterSuite(func() {
 	By("Deleting all CRDs")
@@ -273,3 +278,5 @@ var _ = AfterSuite(func() {
 	Expect(rbacDeletion).To(BeNil())
 	log.Info("deleted CRD and RBAC")
 })
+
+*/


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Puts an upper time limit for BDD runs 
- Removes CRD deletion step as a new feature in operator looks for chaosresults and if it needs to be patched with any info (esp. for abort of engine deletion cases)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests