### PR TITLE
Chore(build): Fix the go build by providing -buildvcs=false flag

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@ RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
 
 RUN go env
 
-RUN CGO_ENABLED=0 go build -o /output/chaos-runner -v ./bin
+RUN CGO_ENABLED=0 go build -buildvcs=false -o /output/chaos-runner -v ./bin
 
 # Packaging stage
 # Image source: https://github.com/litmuschaos/test-tools/blob/master/custom/hardend-alpine/control-plane/Dockerfile


### PR DESCRIPTION
Signed-off-by: uditgaurav <udit@chaosnative.com>

**What this PR does / why we need it**:


Package vcs exposes functions for resolving import paths and using version control systems, which can be used to implement behavior similar to the standard "go get" command.

Error:

```bash
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: missing Git command. See https://golang.org/s/gogetcmd
error obtaining VCS status: exec: "git": executable file not found in $PATH
	Use -buildvcs=false to disable VCS stamping.
The command '/bin/sh -c CGO_ENABLED=0 go build -o /output/chaos-runner -v ./bin' returned a non-zero code: 1
```

Can be fixed by using: `go build -buildvcs=false -o /output/chaos-runner -v ./bin`  (-buildvcs=false flag)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests