### PR TITLE
rename CHAOS_SVC_ACC to CHAOS_SERVICE_ACCOUNT

### DIFF
--- a/pkg/utils/environment.go
+++ b/pkg/utils/environment.go
@@ -18,7 +18,7 @@ func (engineDetails *EngineDetails) SetEngineDetails() *EngineDetails {
 	engineDetails.AppNs = os.Getenv("APP_NAMESPACE")
 	engineDetails.EngineNamespace = os.Getenv("CHAOS_NAMESPACE")
 	engineDetails.AppKind = os.Getenv("APP_KIND")
-	engineDetails.SvcAccount = os.Getenv("CHAOS_SVC_ACC")
+	engineDetails.SvcAccount = os.Getenv("CHAOS_SERVICE_ACCOUNT")
 	engineDetails.ClientUUID = os.Getenv("CLIENT_UUID")
 	engineDetails.AuxiliaryAppInfo = os.Getenv("AUXILIARY_APPINFO")
 	engineDetails.AnnotationKey = os.Getenv("ANNOTATION_KEY")


### PR DESCRIPTION
Signed-off-by: Emily Huynh <emilyhuynh101@gmail.com>

detailed explanation and proposed fix in: #408

related chaos-operator change: https://github.com/litmuschaos/chaos-operator/pull/409