### PR TITLE
feat: update chaos operator pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/jpillora/go-ogle-analytics v0.0.0-20161213085824-14b04e0594ef
-	github.com/litmuschaos/chaos-operator v0.0.0-20221006080214-d78985569b82
+	github.com/litmuschaos/chaos-operator v0.0.0-20221114055503-3d12d34d2032
 	github.com/litmuschaos/elves v0.0.0-20210325101625-5620f93aed51
 	github.com/litmuschaos/litmus-go v0.0.0-20220927112726-25d81a302a70
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-b
 github.com/lightstep/lightstep-tracer-go v0.18.0/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/litmuschaos/chaos-operator v0.0.0-20220927085333-f70f80b9e75f/go.mod h1:CJGiHqC06PQkIBySk/JroB7B2zFebDbkhQ1A6ZbYmHA=
-github.com/litmuschaos/chaos-operator v0.0.0-20221006080214-d78985569b82 h1:FB9P0pfG1bwdb63I9xfZByr3szjfndE8UDOcm4H08xQ=
-github.com/litmuschaos/chaos-operator v0.0.0-20221006080214-d78985569b82/go.mod h1:CJGiHqC06PQkIBySk/JroB7B2zFebDbkhQ1A6ZbYmHA=
+github.com/litmuschaos/chaos-operator v0.0.0-20221114055503-3d12d34d2032 h1:VeVpXvz5JVj28rQZs4DI101b+vVKHIKlUNWGfbDF6V0=
+github.com/litmuschaos/chaos-operator v0.0.0-20221114055503-3d12d34d2032/go.mod h1:CJGiHqC06PQkIBySk/JroB7B2zFebDbkhQ1A6ZbYmHA=
 github.com/litmuschaos/elves v0.0.0-20201107015738-552d74669e3c/go.mod h1:DsbHGNUq/78NZozWVVI9Q6eBei4I+JjlkkD5aibJ3MQ=
 github.com/litmuschaos/elves v0.0.0-20210325101625-5620f93aed51 h1:6CpcGjZsVHMRSB/Z8z9+ectmb1KuQUiy+244jISNhBA=
 github.com/litmuschaos/elves v0.0.0-20210325101625-5620f93aed51/go.mod h1:DsbHGNUq/78NZozWVVI9Q6eBei4I+JjlkkD5aibJ3MQ=


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR updates chaos operator pkg to support `resourceNames` field in k8sprobe

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Related https://github.com/litmuschaos/litmus-go/issues/599

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests