### PR TITLE
Update runner.go

### DIFF
--- a/bin/runner.go
+++ b/bin/runner.go
@@ -5,6 +5,7 @@ import (
 	"github.com/litmuschaos/chaos-runner/pkg/utils"
 	"github.com/litmuschaos/chaos-runner/pkg/utils/analytics"
 	"github.com/sirupsen/logrus"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -20,6 +21,18 @@ func main() {
 
 	engineDetails := utils.EngineDetails{}
 	clients := utils.ClientSets{}
+	// Create a Prometheus client instance.
+       client := prometheus.NewRegistry()
+	// Create a Prometheus Counter metric.
+      counter := prometheus.NewCounter(
+    prometheus.CounterOpts{
+        Name: "chaos_runner_runs",
+        Help: "Number of times the chaos runner has run",
+    },
+)
+
+// Register the counter with the Prometheus client.
+client.Register(counter)
 	// Getting kubeConfig and Generate ClientSets
 	if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
 		log.Errorf("unable to create ClientSets, error: %v", err)


### PR DESCRIPTION
want to add prometheus exporter in the chaos-runner , and refactorize the code .



    To test the code, run the following command:

Code snippet

kubectl apply -f chaos-operator/deploy/chaos_crds.yaml

kubectl apply -f chaos-operator/deploy/operator.yaml

kubectl apply -f chaos-operator/deploy/chaosengines.yaml

kubectl apply -f chaos-operator/deploy/chaosexperiments.yaml

kubectl wait --for=condition=ready pod -l app=chaos-operator

kubectl exec -it chaos-operator-665665555-5555 -- curl localhost:8080/metrics

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [x] Labelled this PR & related issue with `requires-upgrade` tag
- [x] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests