### PR TITLE
UBI migration of Images - chaos-runner

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,14 +17,15 @@ RUN go env
 RUN CGO_ENABLED=0 go build -buildvcs=false -o /output/chaos-runner -v ./bin
 
 # Packaging stage
-# Image source: https://github.com/litmuschaos/test-tools/blob/master/custom/hardend-alpine/control-plane/Dockerfile
-# The base image is non-root (have litmus user) with default litmus directory.
-FROM litmuschaos/infra-alpine
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 LABEL maintainer="LitmusChaos"
 
 ENV RUNNER=/usr/local/bin/chaos-runner 
 
 COPY --from=builder /output/chaos-runner ${RUNNER}
+RUN chown 65534:0 ${RUNNER} && chmod 755 ${RUNNER}
+
+USER 65534
 
 ENTRYPOINT ["/usr/local/bin/chaos-runner"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Migrate the base images of the chaos-runner container images of LitmusChaos from infra-alpine to ubi minimal.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4634  (https://github.com/litmuschaos/litmus/issues/4634)

**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests